### PR TITLE
Add mass to moveable

### DIFF
--- a/src/alias.h
+++ b/src/alias.h
@@ -10,6 +10,7 @@ namespace spacegun {
   using BodyDef = b2BodyDef;
   using Fixture = b2Fixture;
   using FixtureDef = b2FixtureDef;
+  using MassData = b2MassData;
   using PolygonShape = b2PolygonShape;
   using World = b2World;
 

--- a/src/c_moveable.cpp
+++ b/src/c_moveable.cpp
@@ -1,6 +1,4 @@
 
-#include <cassert>
-
 #include <Box2D/Box2D.h>
 
 #include "./c_moveable.h"
@@ -14,7 +12,7 @@ namespace spacegun {
   Moveable::Moveable() :
     body_(nullptr),
     fixture_(nullptr),
-    massData_(nullptr)
+    setMassData_(false)
   {
     b2BodyDef def;
     def.type = b2_dynamicBody;
@@ -28,7 +26,7 @@ namespace spacegun {
            const Vector2d& initialPos) :
     body_(nullptr),
     fixture_(nullptr),
-    massData_(nullptr)
+    setMassData_(false)
   {
     b2BodyDef def;
     def.type = b2_dynamicBody;
@@ -44,8 +42,8 @@ namespace spacegun {
     body_ = world.CreateBody(&bodyDef_);
     fixtureDef_.shape = &shape;
     fixture_ = body_->CreateFixture(&fixtureDef_);
-    if (massData_) {
-      body_->SetMassData(massData_);
+    if (setMassData_) {
+      body_->SetMassData(&massData_);
     }
   }
 
@@ -149,18 +147,18 @@ namespace spacegun {
     if (body_) {
       return body_->GetMass();
     }
-    return massData_->mass;
+    return massData_.mass;
   }
 
   void Moveable::setMass(float mass, const Vector2d& center, float inertia)
   {
-    massData_ = new MassData();
-    massData_->mass = mass;
-    massData_->center = center;
-    massData_->I = inertia;
+    massData_.mass = mass;
+    massData_.center = center;
+    massData_.I = inertia;
+    setMassData_ = true;
 
     if (body_) {
-      body_->SetMassData(massData_);
+      body_->SetMassData(&massData_);
     }
   }
 

--- a/src/c_moveable.cpp
+++ b/src/c_moveable.cpp
@@ -1,16 +1,20 @@
 
+#include <cassert>
+
 #include <Box2D/Box2D.h>
 
 #include "./c_moveable.h"
 
 namespace spacegun {
   using namespace std;
+  using spacegun::MassData;
 
   extern const string COMPONENT_TYPE_MOVEABLE;
 
   Moveable::Moveable() :
     body_(nullptr),
-    fixture_(nullptr)
+    fixture_(nullptr),
+    massData_(nullptr)
   {
     b2BodyDef def;
     def.type = b2_dynamicBody;
@@ -23,7 +27,8 @@ namespace spacegun {
   Moveable::Moveable(const Vector2d& initialVel,
            const Vector2d& initialPos) :
     body_(nullptr),
-    fixture_(nullptr)
+    fixture_(nullptr),
+    massData_(nullptr)
   {
     b2BodyDef def;
     def.type = b2_dynamicBody;
@@ -39,6 +44,9 @@ namespace spacegun {
     body_ = world.CreateBody(&bodyDef_);
     fixtureDef_.shape = &shape;
     fixture_ = body_->CreateFixture(&fixtureDef_);
+    if (massData_) {
+      body_->SetMassData(massData_);
+    }
   }
 
   const string Moveable::getType()
@@ -134,6 +142,26 @@ namespace spacegun {
       fixture_->SetDensity(density);
     }
     fixtureDef_.density = density;
+  }
+
+  float Moveable::getMass()
+  {
+    if (body_) {
+      return body_->GetMass();
+    }
+    return massData_->mass;
+  }
+
+  void Moveable::setMass(float mass, const Vector2d& center, float inertia)
+  {
+    massData_ = new MassData();
+    massData_->mass = mass;
+    massData_->center = center;
+    massData_->I = inertia;
+
+    if (body_) {
+      body_->SetMassData(massData_);
+    }
   }
 
   void Moveable::applyForce(const Vector2d& v)

--- a/src/c_moveable.h
+++ b/src/c_moveable.h
@@ -13,6 +13,7 @@
 
 namespace spacegun {
   using namespace std;
+  using spacegun::MassData;
 
   const string COMPONENT_TYPE_MOVEABLE = "moveable";
 
@@ -36,6 +37,9 @@ namespace spacegun {
       void setRestitution(float restitution);
       float getDensity();
       void setDensity(float density);
+      float getMass();
+      void setMass(float mass, const Vector2d& center,
+          float inertia);
 
       void applyForce(const Vector2d& v);
 
@@ -46,6 +50,7 @@ namespace spacegun {
       BodyDef bodyDef_;
       Fixture* fixture_;
       FixtureDef fixtureDef_;
+      MassData* massData_;
 
   };
 }

--- a/src/c_moveable.h
+++ b/src/c_moveable.h
@@ -50,7 +50,8 @@ namespace spacegun {
       BodyDef bodyDef_;
       Fixture* fixture_;
       FixtureDef fixtureDef_;
-      MassData* massData_;
+      MassData massData_;
+      bool setMassData_;
 
   };
 }

--- a/src/test/movement_test.cpp
+++ b/src/test/movement_test.cpp
@@ -12,6 +12,7 @@
 
 using aronnax::Entity;
 using aronnax::Vector2d;
+using spacegun::Moveable;
 using namespace spacegun;
 using ::testing::_;
 
@@ -108,6 +109,31 @@ TEST(Moveable, getsetDensity) {
   spacegun::Moveable c = spacegun::Moveable();
 
   c.setDensity(expected);
+}
+
+TEST(Moveable, getsetMass) {
+  Moveable c;
+  float expectedMass = 4.5;
+  Vector2d expectedCenter = { 1, 1 };
+
+  c.setMass(expectedMass,
+      expectedCenter,
+      0);
+
+  auto actual = c.getMass();
+
+  EXPECT_EQ(actual, expectedMass);
+
+  Vector2d g = { 0.0, 0.0 };
+  World w(g);
+  PolygonShape p;
+  p.SetAsBox(2, 1);
+
+  c.init(w, p);
+
+  actual = c.getMass();
+
+  EXPECT_EQ(actual, expectedMass);
 }
 
 TEST(Movement, getType) {


### PR DESCRIPTION
Allows direct maniuplation of mass through moveable.

Keeps a pointer on moveable that starts unititialized that gets
initialized when you call set mass. This pointer will be used if not
null on `init` to ensure mass is set correctly before or after init
was called. I did this to ensure consistentcy, you can set mass at
any time in the moveable's lifecycle.

I read after that there may be no direct reason to set mass, it gets
set automatically by the fixture.

Fixes #24
