### PR TITLE
Damageable component with tests

### DIFF
--- a/src/c_damageable.cpp
+++ b/src/c_damageable.cpp
@@ -1,0 +1,29 @@
+
+#include "c_damageable.h"
+
+namespace spacegun {
+
+  extern const string COMPONENT_TYPE_DAMAGEABLE;
+
+  Damageable::Damageable(float health)
+  {
+    initialHealth_ = health;
+    health_ = health;
+  }
+
+  const string Damageable::getType()
+  {
+    return COMPONENT_TYPE_DAMAGEABLE;
+  }
+
+  float Damageable::getHealth()
+  {
+    return health_;
+  }
+
+  void Damageable::applyDamage(float damage)
+  {
+    health_ -= damage;
+  }
+
+}

--- a/src/c_damageable.h
+++ b/src/c_damageable.h
@@ -1,0 +1,30 @@
+
+#ifndef _h_Damageable
+#define _h_Damageable
+
+#include <string>
+
+#include "lib/component.h"
+#include "lib/units.h"
+
+namespace spacegun {
+  using namespace std;
+  using namespace aronnax;
+
+  const string COMPONENT_TYPE_DAMAGEABLE = "damageable";
+
+  class Damageable : public aronnax::Component {
+    public:
+      Damageable(float health=0);
+      const string getType();
+      float getHealth();
+      void applyDamage(float damage);
+
+    private:
+      float health_;
+      float initialHealth_;
+  };
+
+}
+
+#endif

--- a/src/test/damage_test.cpp
+++ b/src/test/damage_test.cpp
@@ -1,0 +1,41 @@
+
+#include <gtest/gtest.h>
+
+#include "../c_damageable.h"
+
+using spacegun::COMPONENT_TYPE_DAMAGEABLE;
+using spacegun::Damageable;
+
+TEST(Damageable, Constructor) {
+  Damageable c;
+
+  auto actual = c.getHealth();
+  EXPECT_EQ(actual, 0);
+
+  auto expectedHealth = 120;
+
+  Damageable c2(expectedHealth);
+  actual = c2.getHealth();
+
+
+  EXPECT_EQ(actual, expectedHealth);
+}
+
+TEST(Damageable, getType) {
+  Damageable c;
+
+  auto actual = c.getType();
+
+  EXPECT_EQ(actual, COMPONENT_TYPE_DAMAGEABLE);
+}
+
+TEST(Damageable, applyDamage) {
+  Damageable c(100);
+  float damage = 25.5;
+  float expected = 100 - damage;
+
+  c.applyDamage(damage);
+  auto actual = c.getHealth();
+
+  EXPECT_EQ(actual, expected);
+}


### PR DESCRIPTION
Will init the component with full health passed in and subtract damage
from this initial number. This interface is meant to limit errors with
incorrectly setting health and keep things simple.
