### PR TITLE
Set user data on moveable

### DIFF
--- a/src/c_moveable.cpp
+++ b/src/c_moveable.cpp
@@ -64,6 +64,11 @@ namespace spacegun {
     }
   }
 
+  void Moveable::setDamageable()
+  {
+    body_->SetUserData(this);
+  }
+
   const string Moveable::getType()
   {
     return COMPONENT_TYPE_MOVEABLE;

--- a/src/c_moveable.h
+++ b/src/c_moveable.h
@@ -27,6 +27,7 @@ namespace spacegun {
                const Vector2d& initialPos,
                float initialAngle);
       void init(World& world, Shape& shape);
+      void setDamageable();
       const string getType();
       Vector2d getVel();
       // TODO should this be set force?

--- a/src/s_movement.cpp
+++ b/src/s_movement.cpp
@@ -4,6 +4,7 @@
 #include "lib/entity.h"
 
 #include "s_movement.h"
+#include "c_damageable.h"
 #include "c_moveable.h"
 #include "c_rectangular.h"
 #include "c_shaped.h"
@@ -44,6 +45,9 @@ namespace spacegun {
     auto shape = xs->getShape();
 
     m->init(*world, *shape);
+    if (e.hasComponent(COMPONENT_TYPE_DAMAGEABLE)) {
+      m->setDamageable();
+    }
   }
 
 }


### PR DESCRIPTION
Using a separate method to set it, and theres a check in movement
system that calls it if damageable.

Might make more sense as a bool on `init` as this can only be set
after init is called.

Fixes #65.
