### PR TITLE
Added impact movement

### DIFF
--- a/src/lib/units.h
+++ b/src/lib/units.h
@@ -3,6 +3,7 @@
 #include <cfloat>
 #include <cmath>
 #include <string>
+#include <vector>
 
 #include <Box2D/Box2D.h>
 #include "SDL2/SDL.h"
@@ -291,6 +292,38 @@ namespace aronnax {
 
     private:
       float direction_;
+  };
+
+  const unsigned int EV_USER_IMPACT = 203;
+  class EvImpact : public Ev
+  {
+    public:
+      EvImpact(const Ev& ev) :
+        Ev(ev)
+      { }
+
+      EvImpact(vector<float> impulses) :
+        normalImpulses_(impulses)
+      { }
+
+      unsigned int getEventCode() { return EV_USER_IMPACT; }
+
+      vector<float> getImpulses()
+      {
+        return normalImpulses_;
+      }
+
+      float getTotalImpulses()
+      {
+        float total = 0.0f;
+        for (auto i : normalImpulses_) {
+          total += i;
+        }
+        return total;
+      }
+
+    private:
+      vector<float> normalImpulses_;
   };
 }
 

--- a/src/lib/units_test.cpp
+++ b/src/lib/units_test.cpp
@@ -87,3 +87,33 @@ TEST(EvUserRotation, getsetDirection) {
 
   EXPECT_EQ(actual, expected);
 }
+
+TEST(EvImpact, Constructor) {
+  vector<float> expected;
+  expected.push_back(1.0f);
+  EvImpact ev(expected);
+
+  auto actual = ev.getImpulses();
+
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(EvImpact, getEventCode) {
+  vector<float> v;
+  EvImpact ev(v);
+
+  auto actual = ev.getEventCode();
+
+  EXPECT_EQ(actual, EV_USER_IMPACT);
+}
+
+TEST(EvImpact, getTotalImpulses) {
+  vector<float> expected;
+  expected.push_back(1.0f);
+  expected.push_back(2.0f);
+  EvImpact ev(expected);
+
+  auto actual = ev.getTotalImpulses();
+
+  EXPECT_FLOAT_EQ(actual, 3.0f);
+}


### PR DESCRIPTION
An impact event to represent when a certain impact has happened. It
follows box2d conventions of having multiple implulses that you can
combine to one float for the total impulse, which will be used to
calculate the amount of force, and then the amount of damage.

The Box2d listener will be calling this.

Fixes #63.
