### PR TITLE
Impact system to pass off damage

### DIFF
--- a/src/lib/units.h
+++ b/src/lib/units.h
@@ -294,7 +294,7 @@ namespace aronnax {
       float direction_;
   };
 
-  const unsigned int EV_USER_IMPACT = 203;
+  const unsigned int EV_IMPACT = 203;
   class EvImpact : public Ev
   {
     public:
@@ -306,7 +306,7 @@ namespace aronnax {
         normalImpulses_(impulses)
       { }
 
-      unsigned int getEventCode() { return EV_USER_IMPACT; }
+      unsigned int getEventCode() { return EV_IMPACT; }
 
       vector<float> getImpulses()
       {

--- a/src/lib/units_test.cpp
+++ b/src/lib/units_test.cpp
@@ -104,7 +104,7 @@ TEST(EvImpact, getEventCode) {
 
   auto actual = ev.getEventCode();
 
-  EXPECT_EQ(actual, EV_USER_IMPACT);
+  EXPECT_EQ(actual, EV_IMPACT);
 }
 
 TEST(EvImpact, getTotalImpulses) {

--- a/src/s_impacts.cpp
+++ b/src/s_impacts.cpp
@@ -1,0 +1,51 @@
+
+#include "lib/units.h"
+#include "s_impacts.h"
+
+#include "c_damageable.h"
+
+namespace spacegun {
+  using std::string;
+
+  using aronnax::EV_IMPACT;
+  using aronnax::Entity;
+  using aronnax::Entities;
+  using aronnax::EvImpact;
+
+  extern const string COMPONENT_TYPE_DAMAGEABLE;
+
+  void Impacts::init(Entities& entities)
+  {
+    for (auto e : entities) {
+      bindEntity(*e);
+    }
+  }
+
+  void Impacts::onAddEntity(Entity& entity)
+  {
+    bindEntity(entity);
+  }
+
+  void Impacts::bindEntity(Entity& entity)
+  {
+    entity.on(EV_IMPACT,
+        [&](EvImpact* ev) {
+      handleImpact(entity, *ev);
+    });
+  }
+
+  void Impacts::handleImpact(Entity& entity, EvImpact& ev)
+  {
+    auto c = entity.getComponent<Damageable>(COMPONENT_TYPE_DAMAGEABLE);
+    auto totalImpulse = ev.getTotalImpulses();
+
+    c->applyDamage(totalImpulse);
+  }
+
+  const string& Impacts::getType()
+  {
+    // TODO should this impact component be linked to damageable component.
+    return COMPONENT_TYPE_DAMAGEABLE;
+  }
+
+}

--- a/src/s_impacts.h
+++ b/src/s_impacts.h
@@ -1,0 +1,35 @@
+
+#ifndef _h_Impacts
+#define _h_Impacts
+
+#include <cstdint>
+
+#include "lib/entity.h"
+#include "lib/system.h"
+#include "lib/units.h"
+
+namespace spacegun {
+  using std::string;
+  using aronnax::EV_IMPACT;
+  using aronnax::Entity;
+  using aronnax::Entities;
+  using aronnax::EvImpact;
+
+  class Impacts: public aronnax::System
+  {
+    public:
+      Impacts() {};
+      void init(Entities& entities);
+      void update(const uint32_t dt, Entities& entities) {};
+      void render(const uint32_t dt, Entities& entities) {};
+      void onAddEntity(Entity& entity);
+      const string& getType();
+
+    private:
+      void bindEntity(Entity& entity);
+      void handleImpact(Entity& entity, EvImpact& ev);
+
+  };
+}
+
+#endif

--- a/src/test/impacts_test.cpp
+++ b/src/test/impacts_test.cpp
@@ -1,0 +1,36 @@
+
+#include <gtest/gtest.h>
+
+#include "../lib/entity.h"
+#include "../lib/units.h"
+
+#include "../c_damageable.h"
+#include "../s_impacts.h"
+
+using std::vector;
+using namespace spacegun;
+
+TEST(Impacts, onAddEntity) {
+  vector<float> impulses;
+  float expectedA = 2.0f;
+  float expectedB = 2.5f;
+  float expected = 100 - expectedA - expectedB;
+  impulses.push_back(expectedA);
+  impulses.push_back(expectedB);
+  EvImpact ev(impulses);
+
+  Damageable c(100);
+  auto e = new Entity();
+  e->addComponent(&c);
+
+  Impacts s;
+  s.onAddEntity(*e);
+
+  e->emit(EV_IMPACT, &ev);
+
+  auto actual = c.getHealth();
+
+  EXPECT_FLOAT_EQ(actual, expected);
+
+  delete e;
+}


### PR DESCRIPTION
Code will call a EvImpulse event from the box2d listener which will
emit to an entity which will end up here. This allows two systems
to take care of box2d collisions.

Might be confusing that the Impacts system is tied to the damageable
component.

Fixes #62.
