### PR TITLE
Change horizontal direction when facing south

### DIFF
--- a/src/c_oriented.cpp
+++ b/src/c_oriented.cpp
@@ -20,7 +20,7 @@ namespace spacegun {
     return angle;
   }
 
-  bool Oriented::facingNorth()
+  bool Oriented::facingSouth()
   {
     auto angle = getNormalizedAngle();
     if (angle > 45 && angle < 135) {

--- a/src/c_oriented.cpp
+++ b/src/c_oriented.cpp
@@ -23,7 +23,7 @@ namespace spacegun {
   bool Oriented::facingNorth()
   {
     auto angle = getNormalizedAngle();
-    if (angle < 90 || angle > 270) {
+    if (angle > 45 && angle < 135) {
       return true;
     }
     return false;

--- a/src/c_oriented.h
+++ b/src/c_oriented.h
@@ -26,7 +26,7 @@ namespace spacegun {
       };
       // TODO move to Moveable
       float getNormalizedAngle();
-      bool facingNorth();
+      bool facingSouth();
 
     private:
       Moveable* moveable_;

--- a/src/s_thrust.cpp
+++ b/src/s_thrust.cpp
@@ -1,11 +1,11 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 
 #include "lib/units.h"
 #include "c_thrustable.h"
 #include "c_moveable.h"
+#include "c_oriented.h"
 #include "s_thrust.h"
 
 namespace spacegun {
@@ -44,6 +44,7 @@ namespace spacegun {
       aronnax::Entity& entity)
   {
     auto moveable = entity.getComponent<Moveable>(COMPONENT_TYPE_MOVEABLE);
+    auto oriented = entity.getComponent<Oriented>(COMPONENT_TYPE_ORIENTED);
     auto thrustable = entity.getComponent<Thrustable>(
         COMPONENT_TYPE_THRUSTABLE);
     auto thrustFactor = thrustable->getFactor();
@@ -51,7 +52,8 @@ namespace spacegun {
 
     auto angle = moveable->getAngle();
 
-    auto force = getForce(direction, angle);
+    auto facingNorth = oriented->facingNorth();
+    auto force = getForce(direction, angle, !facingNorth);
     force *= thrustFactor;
     if (direction == Vector2d(1, 1)) {
       force *= 3;
@@ -73,7 +75,7 @@ namespace spacegun {
     moveable->applyTorque(torque);
   }
 
-  Vector2d Thrust::getForce(Vector2d direction, float angle)
+  Vector2d Thrust::getForce(Vector2d direction, float angle, bool facingSouth)
   {
     Vector2d right = { 1, 0 };
     Vector2d left = { -1, 0 };
@@ -93,6 +95,9 @@ namespace spacegun {
       force = currForce;
       force.x *= direction.x;
       force.y *= direction.y;
+      if (facingSouth) {
+        force.x *= -1;
+      }
     }
 
     return force;

--- a/src/s_thrust.cpp
+++ b/src/s_thrust.cpp
@@ -44,7 +44,6 @@ namespace spacegun {
       aronnax::Entity& entity)
   {
     auto moveable = entity.getComponent<Moveable>(COMPONENT_TYPE_MOVEABLE);
-    auto oriented = entity.getComponent<Oriented>(COMPONENT_TYPE_ORIENTED);
     auto thrustable = entity.getComponent<Thrustable>(
         COMPONENT_TYPE_THRUSTABLE);
     auto thrustFactor = thrustable->getFactor();
@@ -52,8 +51,13 @@ namespace spacegun {
 
     auto angle = moveable->getAngle();
 
-    auto facingNorth = oriented->facingNorth();
-    auto force = getForce(direction, angle, !facingNorth);
+    bool facingSouth = false;
+    if (entity.hasComponent(COMPONENT_TYPE_ORIENTED)) {
+      auto oriented = entity.getComponent<Oriented>(COMPONENT_TYPE_ORIENTED);
+      facingSouth = oriented->facingSouth();
+    }
+
+    auto force = getForce(direction, angle, facingSouth);
     force *= thrustFactor;
     if (direction == Vector2d(1, 1)) {
       force *= 3;
@@ -86,6 +90,9 @@ namespace spacegun {
     currForce.y = sin(angle);
 
     if (direction == right || direction == left) {
+      if (facingSouth) {
+        direction.x *= -1;
+      }
       float ninety = 1.5708f * direction.x;
       auto cs = cos(ninety);
       auto sn = sin(ninety);
@@ -95,9 +102,6 @@ namespace spacegun {
       force = currForce;
       force.x *= direction.x;
       force.y *= direction.y;
-      if (facingSouth) {
-        force.x *= -1;
-      }
     }
 
     return force;

--- a/src/s_thrust.h
+++ b/src/s_thrust.h
@@ -26,7 +26,7 @@ namespace spacegun {
           aronnax::Entity& entity);
       void handleRotationKey(aronnax::EvUserRotation& ev,
           aronnax::Entity& entity);
-      Vector2d getForce(Vector2d direction, float angle);
+      Vector2d getForce(Vector2d direction, float angle, bool facingSouth);
 
   };
 }

--- a/src/test/orientation_test.cpp
+++ b/src/test/orientation_test.cpp
@@ -41,7 +41,7 @@ TEST_F(OrientedTest, getType) {
   EXPECT_EQ(COMPONENT_TYPE_ORIENTED, actual);
 }
 
-TEST_F(OrientedTest, facingNorth) {
-  auto actual = oriented_->facingNorth();
+TEST_F(OrientedTest, facingSouth) {
+  auto actual = oriented_->facingSouth();
   EXPECT_FALSE(actual);
 }


### PR DESCRIPTION
Has thrust check the `facingNorth()` function and passes it off
when getting force. This function will reverse the force x direction
by minus 1 when the control direction is top and down.

Had to change the oriented facing north function because the values
were not what I expected. I'm not sure what was going on here. I also
reversed facingNorth in thrust so it's techincally facing South. I did
this just because I think north facing should be what you use as a base.
Might make sense to change to facing south instead.

This just changes the x direction because I only want to modify that
direction when they're facing south. This means the player will have
their right and left thrusts switched when facing south, so it means
they're always the same physical direction, hopefully making it easier.

I also limited the facing north angle so it's not when the player is
facing west or east at all, otherwise the back and forward controls
are reversed which is way more confusing.
