### PR TITLE
Allow makefile to configure google tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,12 @@ LIBDISTS = $(addprefix $(DISTDIR)/,$(LIBS))
 GTEST_HEADERS = $(GTEST_DIR)/include
 GMOCK_HEADERS = $(GMOCK_DIR)/include
 
-LIBGTEST = /usr/lib/libgtest_main.so /usr/lib/libgtest.so
-LIBGMOCK = /usr/lib/libgmock_main.so /usr/lib/libgmock.so
+ifndef LIBGTEST
+LIBGTEST = /usr/lib/libgtest_main.a /usr/lib/libgtest.so
+endif
+ifndef LIBGMOCK
+LIBGMOCK = /usr/lib/libgmock_main.a /usr/lib/libgmock.so
+endif
 
 SUBDIRS = src/lib
 


### PR DESCRIPTION
Different confirgurations use different paths for google test and
mock.
