### PR TITLE
Sprited component

### DIFF
--- a/src/c_sprited.cpp
+++ b/src/c_sprited.cpp
@@ -1,0 +1,20 @@
+
+#include <string>
+
+#include "c_sprited.h"
+
+namespace spacegun {
+  using std::string;
+
+  extern const string COMPONENT_TYPE_SPRITED;
+
+  const string Sprited::getType()
+  {
+    return COMPONENT_TYPE_SPRITED;
+  }
+
+  const string& Sprited::getFilePath()
+  {
+    return filePath_;
+  }
+}

--- a/src/c_sprited.h
+++ b/src/c_sprited.h
@@ -1,0 +1,36 @@
+
+#ifndef _h_Sprited
+#define _h_Sprited
+
+#include <string>
+
+#include <Box2D/Box2D.h>
+
+#include "lib/component.h"
+#include "lib/entity.h"
+#include "lib/units.h"
+
+#include "alias.h"
+
+namespace spacegun {
+  using std::string;
+  using aronnax::Component;
+  using aronnax::Entity;
+  using aronnax::Vector2d;
+
+  const string COMPONENT_TYPE_SPRITED = "sprited";
+
+  class Sprited: public Component
+  {
+    public:
+      Sprited(string filePath) :
+        filePath_(filePath) {};
+      const string getType();
+      const string& getFilePath();
+
+    private:
+      string filePath_;
+  };
+}
+
+#endif

--- a/src/test/movement_test.cpp
+++ b/src/test/movement_test.cpp
@@ -54,8 +54,9 @@ TEST(Moveable, init) {
   PolygonShape p;
   p.SetAsBox(2, 1);
   Moveable c;
+  Entity e;
 
-  c.init(w, p);
+  c.init(w, p, e);
 
   auto actual = c.getBody();
 
@@ -103,13 +104,14 @@ TEST(Moveable, getAngle) {
   World w(g);
   PolygonShape p;
   p.SetAsBox(2, 1);
+  Entity e;
 
   Moveable c = Moveable(vel, initPos, expectedAngle);
 
   auto actual = c.getAngle();
   EXPECT_EQ(actual, expectedAngle);
 
-  c.init(w, p);
+  c.init(w, p, e);
 
   actual = c.getAngle();
   EXPECT_EQ(actual, expectedAngle);
@@ -161,8 +163,9 @@ TEST(Moveable, getsetMass) {
   World w(g);
   PolygonShape p;
   p.SetAsBox(2, 1);
+  Entity e;
 
-  c.init(w, p);
+  c.init(w, p, e);
 
   actual = c.getMass();
 
@@ -212,8 +215,9 @@ TEST(Moveable, applyForce) {
   p.SetAsBox(2, 1);
 
   Moveable m(initV, initP);
+  Entity e;
 
-  m.init(w, p);
+  m.init(w, p, e);
 
   auto actual = m.getVel();
 

--- a/src/test/sprite_test.cpp
+++ b/src/test/sprite_test.cpp
@@ -1,0 +1,38 @@
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "../lib/units.h"
+
+#include "../c_sprited.h"
+
+using std::string;
+using namespace spacegun;
+using aronnax::Vector2d;
+
+
+TEST(Sprited, DefaultConstructor) {
+  string expected = "/path/to/img.gif";
+  Sprited c = Sprited(expected);
+  auto actual = c.getFilePath();
+
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(Sprited, getType) {
+  Sprited c = Sprited("/path");
+
+  auto actual = c.getType();
+
+  EXPECT_EQ(COMPONENT_TYPE_SPRITED, actual);
+}
+
+TEST(Sprited, getFilePath) {
+  string expected = "/path/to/img.gif";
+  Sprited c = Sprited(expected);
+
+  auto actual = c.getFilePath();
+
+  EXPECT_EQ(expected, actual);
+}

--- a/src/test/thrust_test.cpp
+++ b/src/test/thrust_test.cpp
@@ -102,7 +102,7 @@ TEST(Thrust, onAddEntity) {
   Thrustable ct(factor);
   Entity* e = new Entity();
   Thrust s;
-  cm.init(w, p);
+  cm.init(w, p, *e);
 
   e->addComponent(&cm);
   e->addComponent(&ct);


### PR DESCRIPTION
That just carries the file path to the image. It will have it's image
loaded with SDL into a surface probably in the rectangle renderer,
which has to be abstracted later with polygons.

Don't have a setter for image path, it's probably not needed.

Also fixed tests.

Fixes #149 
