### PR TITLE
Fix health not resetting to 100

### DIFF
--- a/src/s_death.cpp
+++ b/src/s_death.cpp
@@ -18,6 +18,7 @@ namespace spacegun {
   using aronnax::EV_PLAYER_DEATH;
   using aronnax::Entity;
   using aronnax::Entities;
+  using aronnax::EvImpact;
   using aronnax::EvPlayerDeath;
   using aronnax::Vector2d;
 
@@ -76,6 +77,10 @@ namespace spacegun {
       auto s = entity.getComponent<Notification>(COMPONENT_TYPE_NOTIFICATION);
       auto lineNum = mortal->notificationLine;
       s->updateLine(lineNum, msg);
+      vector<float> total;
+      total.push_back(0.0);
+      EvImpact ev(total);
+      entity.emit(EV_IMPACT, &ev);
     }
   }
 


### PR DESCRIPTION
Emit an impact event of 0 damage on death so the notification line
gets updated with the 100 health number immediately on death.

Before the notification wasn't getting updated because death event
was only adding a death to notification. So now just emit a fake
impact event after entity is reset so it will get new number.

Also tried to get impacts system to bind to death as well as impact
to update with newest health, but I think based on sequence of
events, the health isn't reset at that point yet (the impacts binding
is called before the death one).
